### PR TITLE
Fix Ajax "same origin policy" issue when port != 80 by using window.location.host

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -18,7 +18,7 @@ var config = new Settings(
   // elasticsearch installed on. You probably want to set it to the FQDN of your
   // elasticsearch host
   
-  elasticsearch:    "http://"+window.location.hostname,
+  elasticsearch:    "http://"+window.location.host,
   // elasticsearch: 'http://localhost:9200',
   kibana_index:     "kibana-int",
   modules:          ['histogram','map','pie','table','query',


### PR DESCRIPTION
If the web server configuration is using a port different than 80, i.e. node['kibana']['webserver_port'] != 80 than we must also make sure that kibana will send the AJAX requests (_search, _aliases ...) to the same host:port, else the AJAX request will not be allowed to pass throw [1](https://en.wikipedia.org/wiki/Same_origin_policy#Origin_determination_rules).
