### PR TITLE
support for multiple protocol

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -18,7 +18,7 @@ var config = new Settings(
   // elasticsearch installed on. You probably want to set it to the FQDN of your
   // elasticsearch host
   
-  elasticsearch:    "http://"+window.location.host,
+  elasticsearch:    window.location.protocol+"//"+window.location.host,
   // elasticsearch: 'http://localhost:9200',
   kibana_index:     "kibana-int",
   modules:          ['histogram','map','pie','table','query', 'filtering',


### PR DESCRIPTION
setting config.js to set the protocol based on the current url.  this means when https support is added and accessed by the users browser the elasticsearch proxying will work through it.
