### PR TITLE
Replace the new "Welcome page" with the logstash dashboard

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,4 +49,9 @@ template "#{node['kibana']['installdir']}/current/config.js" do
   user kibana_user
 end
 
+link "#{node['kibana']['installdir']}/current/dashboards/default.json" do
+  to "logstash.json"
+  only_if { !File::symlink?("#{node['kibana']['installdir']}/current/dashboard/default.json")
+end
+
 include_recipe "kibana::#{node['kibana']['webserver']}"


### PR DESCRIPTION
The latest versions of Kibana 3 have a welcome page that asks the user to move a file in the _dashboards_ directory. This makes a symlink form default.json to logstash.json .
