### PR TITLE
Adding terms module to config.js

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -21,8 +21,9 @@ var config = new Settings(
   elasticsearch:    "http://"+window.location.host,
   // elasticsearch: 'http://localhost:9200',
   kibana_index:     "kibana-int",
-  modules:          ['histogram','map','pie','table','query', 'filtering',
+  modules:          ['histogram','map','pie','table','filtering',
                     'timepicker','text','fields','hits','dashcontrol',
-                    'column','derivequeries','trends','bettermap'],
+                    'column','derivequeries','trends','bettermap','query',
+                    'terms'],
   }
 );


### PR DESCRIPTION
The terms module is relatively new and is set to replace pie. It is already in kibana master.

Also makes a small change to the placement of "query" to duplicate what is in kibana master.

See: https://github.com/elasticsearch/kibana/commit/3a06457c5d888551a564c2325ad60ad85a22987f#panels/terms/module.html
