### PR TITLE
Enable 'terms' module in templates/default/config.js.erb

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -21,8 +21,9 @@ var config = new Settings(
   elasticsearch:    "http://"+window.location.host,
   // elasticsearch: 'http://localhost:9200',
   kibana_index:     "kibana-int",
-  modules:          ['histogram','map','pie','table','query', 'filtering',
+  modules:          ['histogram','map','pie','table','filtering',
                     'timepicker','text','fields','hits','dashcontrol',
-                    'column','derivequeries','trends','bettermap'],
+                    'column','derivequeries','trends','bettermap','query',
+                    'terms'],
   }
 );


### PR DESCRIPTION
the config.js.erb template was missing 'terms' in the module list. so I added it.
