### PR TITLE
Enable template_cookbook attribute for apache configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 metadata.json
 .vagrant
+*.iml

--- a/attributes/apache.rb
+++ b/attributes/apache.rb
@@ -1,2 +1,3 @@
 default['kibana']['apache']['template'] = 'kibana-apache.conf.erb'
+default['kibana']['apache']['template_cookbook'] = 'kibana'
 default['kibana']['apache']['enable_default_site'] = false

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -25,9 +25,8 @@ include_recipe "apache2::mod_proxy"
 include_recipe "apache2::mod_proxy_http"
 
 web_app "#{node['kibana']['webserver_hostname']}-#{node['kibana']['webserver_port']}" do
-  cookbook       "kibana"
+  cookbook       node['kibana']['apache']['template_cookbook']
   docroot        node['kibana']['installdir']
-  server_name    node['kibana']['webserver_hostname']
   template       node['kibana']['apache']['template']
   es_server      node['kibana']['es_server']
   es_port        node['kibana']['es_port']


### PR DESCRIPTION
I was unable to use my own apache template from my own cookbook. This pull request enables this in the same way the nginx template_cookbook attribute works.
