### PR TITLE
Add mod_dir to the needed apache2 modules (kibana::apache)

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -21,6 +21,7 @@
 node.set['apache2']['default_site_enabled'] = node['kibana']['apache']['enable_default_site']
 
 include_recipe "apache2"
+include_recipe "apache2::mod_dir"
 include_recipe "apache2::mod_proxy"
 include_recipe "apache2::mod_proxy_http"
 


### PR DESCRIPTION
Although the module might be loaded by the [default attributes of the apache2 cookbook](https://github.com/opscode-cookbooks/apache2/blob/master/attributes/default.rb#L161), someone might very well have overridden these.  So... explicitly including all dependencies FTW :)

Without mod_dir, accessing http://$IP:8400 will not get you to the dashboard `index.html`.
