### PR TITLE
allow choosing the web_app template's cookbook

### DIFF
--- a/attributes/apache.rb
+++ b/attributes/apache.rb
@@ -1,2 +1,3 @@
 default['kibana']['apache']['template'] = 'kibana-apache.conf.erb'
+default['kibana']['apache']['template_cookbook'] = 'kibana'
 default['kibana']['apache']['enable_default_site'] = false

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -25,7 +25,7 @@ include_recipe "apache2::mod_proxy"
 include_recipe "apache2::mod_proxy_http"
 
 web_app "#{node['kibana']['webserver_hostname']}-#{node['kibana']['webserver_port']}" do
-  cookbook       "kibana"
+  cookbook       node['kibana']['apache']['template_cookbook']
   docroot        node['kibana']['installdir']
   server_name    node['kibana']['webserver_hostname']
   template       node['kibana']['apache']['template']


### PR DESCRIPTION
Hello,

to override the apache config created by this cookbook, it would be great to be able to chose the cookbook where the template is chosen from.  Looking at the possibility to change the template's file, it seems to me like this was intended anyways.

Thanks for the great cookbook, btw,
Stephan
