### PR TITLE
add proxy passthrough for elasticsearch /_nodes

### DIFF
--- a/templates/default/kibana-apache.conf.erb
+++ b/templates/default/kibana-apache.conf.erb
@@ -21,7 +21,7 @@
   </Proxy>
  
   # Proxy for _aliases and .*/_search
-  <LocationMatch "^(/_aliases|/.*/_mapping|.*/_search)$">
+  <LocationMatch "^(/_aliases|_nodes|/.*/_mapping|.*/_search)$">
     ProxyPassMatch http://<%= @params[:es_server] %>:<%= @params[:es_port] %>
     ProxyPassReverse http://<%= @params[:es_server] %>:<%= @params[:es_port] %>
   </LocationMatch>

--- a/templates/default/kibana-nginx.conf.erb
+++ b/templates/default/kibana-nginx.conf.erb
@@ -9,7 +9,7 @@ server {
     index  index.html  index.htm; 
   }
 
-  location ~ ^/_aliases$ {
+  location ~ ^/_(aliases|nodes)$ {
     proxy_pass http://<%= @es_server %>:<%= @es_port %>;
     proxy_read_timeout 90;
   }


### PR DESCRIPTION
kibana makes a request to /_nodes, this adds the proxying of those requests.
