### PR TITLE
Allow the configuration for the elasticsearch server in config.js to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ As with most cookbooks I write, this one is hopefully flexible enough to be wrap
 - `node['kibana']['webserver_aliases']` - Array of any secondary hostnames that are valid vhosts
 - `node['kibana']['webserver_listen']` - The ip address the web server will listen on
 - `node['kibana']['webserver_port']` - The port the webserver will listen on
+- `node['kibana']['elasticsearch']['server']` - The URL or a javascript expression with for the elasticsearch server to connect to
 
 #### kibana::nginx
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,5 @@ default['kibana']['webserver_hostname'] = node.name
 default['kibana']['webserver_aliases'] = [node.ipaddress]
 default['kibana']['webserver_listen'] = node.ipaddress
 default['kibana']['webserver_port'] = 80
+
+default['kibana']['elasticsearch']['server'] = "window.location.protocol+\"//\"+window.location.hostname+\":\"+window.location.port"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,6 +62,9 @@ template "#{node['kibana']['installdir']}/current/config.js" do
   cookbook node['kibana']['config_cookbook']
   mode "0750"
   user kibana_user
+  variables(
+    :elasticsearch_server => node['kibana']['elasticsearch']['server']
+  )
 end
 
 link "#{node['kibana']['installdir']}/current/app/dashboards/default.json" do

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -18,7 +18,7 @@ function (Settings) {
      * elasticsearch host
      * @type {String}
      */
-    elasticsearch: window.location.protocol+"//"+window.location.hostname+":"+window.location.port,
+    elasticsearch: <%= @elasticsearch_server %>,
 
     /**
      * The default ES index to use for storing Kibana specific object


### PR DESCRIPTION
This PR addresses the need to be able to override the location of the elasticsearch server attribute in the config.js. 

See my comment regarding this issue: https://github.com/lusis/chef-kibana/commit/54afc93f6fe61d648fe8e1f4e12ed8a885c6847a#commitcomment-4409963