### PR TITLE
proxy the backend healthcheck path

### DIFF
--- a/templates/default/kibana-nginx.conf.erb
+++ b/templates/default/kibana-nginx.conf.erb
@@ -25,6 +25,10 @@ server {
     proxy_pass http://<%= @es_server %>:<%= @es_port %>;
     proxy_read_timeout 90;
   }
+  location ~ ^/_cluster/health$ {
+    proxy_pass http://<%= @es_server %>:<%= @es_port %>;
+    proxy_read_timeout 90;
+  }
   # Password protected end points
   location ~ ^/kibana-int/dashboard/.*$ {
     proxy_pass http://<%= @es_server %>:<%= @es_port %>;


### PR DESCRIPTION
Enable the ability to monitor both the backend health, and that proxying is working.
