### PR TITLE
Handle proxying for the new Kibana 3 milestone 5

### DIFF
--- a/templates/default/kibana-apache.conf.erb
+++ b/templates/default/kibana-apache.conf.erb
@@ -21,7 +21,7 @@
   </Proxy>
 
   # Proxy for _aliases and .*/_search
-  <LocationMatch "^(/_aliases|/_nodes|/.*/_mapping|.*/_search)$">
+  <LocationMatch "^(/_aliases|/_nodes|/.*/_mapping|/.*/_search|/.*/_aliases)$">
     ProxyPassMatch <%= @params[:es_scheme] %><%= @params[:es_server] %>:<%= @params[:es_port] %>
     ProxyPassReverse <%= @params[:es_scheme] %><%= @params[:es_server] %>:<%= @params[:es_port] %>
   </LocationMatch>

--- a/templates/default/kibana-nginx.conf.erb
+++ b/templates/default/kibana-nginx.conf.erb
@@ -25,6 +25,10 @@ server {
     proxy_pass <%= @es_scheme %><%= @es_server %>:<%= @es_port %>;
     proxy_read_timeout 90;
   }
+  location ~ ^/.*/_aliases$ {
+    proxy_pass <%= @es_scheme %><%= @es_server %>:<%= @es_port %>;
+    proxy_read_timeout 90;
+  }
   location ~ ^/kibana-int/dashboard/.*$ {
     proxy_pass <%= @es_scheme %><%= @es_server %>:<%= @es_port %>;
     proxy_read_timeout 90;


### PR DESCRIPTION
Kibana 3 Milestone 5 handles the requests to ElasticSearch a bit different
from the way older versions did. More info about that change can be found
here:

https://github.com/elasticsearch/kibana/commit/629705ea448ce4dc2838f32f95183ab25d3242ea

This change broke Kibana when sending queries through an (nginx|apache) proxy; no
graphs or data were shown at all.

I found that adding a proxy for /.*/_aliases resolved this issue.
