### PR TITLE
changing permissions on config.js so everyone can read it

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,7 +78,7 @@ end
 template "#{node['kibana']['web_dir']}/config.js" do
   source node['kibana']['config_template']
   cookbook node['kibana']['config_cookbook']
-  mode "0750"
+  mode "0644"
   user kibana_user
 end
 


### PR DESCRIPTION
Using this cookbook to install kibana served by nginx.  Testing with local Vagrant VM (and eventually running it on AWS).

Installs successfully and starts nginx but when I go to kibana in the browser the request for config.js responds with a 403 because the permissions on the config file is different than that of the other kibana files and the nginx user can't read the config file because they arent the owner.  This change makes it so the file can be read by everyone.

Maybe something else in my set up is wrong so let me know if theres any other info you need.  Thanks!