### PR TITLE
Added support and docs for alternate webserver log directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ If you would like to modify the `nginx` or `apache` parameters, you should:
 - modify the template as you see fit (add auth, setup ssl)
 - use the appropriate webserver template attributes to point to your cookbook and template
 
+To modify the webserver log path, set the attributes for your selected webserver:
+
+- `node['apache']['log_dir'] = '/var/log/httpd'`
+- `node['nginx']['log_dir'] = '/var/log/nginx'`
+
 Testing
 -------
 #### Vagrant

--- a/templates/default/kibana-nginx.conf.erb
+++ b/templates/default/kibana-nginx.conf.erb
@@ -2,7 +2,7 @@ server {
   listen                <%= @listen_address %>:<%= @listen_port %>;
 
   server_name           <%= @server_name %> <%= @server_aliases.join(" ") %>;
-  access_log            /var/log/nginx/<%= @server_name %>.access.log;
+  access_log            <%= node['nginx']['log_dir'] %>/<%= @server_name %>.access.log;
 
   location / {
     root  <%= @kibana_dir %>;


### PR DESCRIPTION
The nginx template has been updated to use the nginx cookbook's default log_dir like the apache template already does.

Also added documentation to the README on configuring this.
