### PR TITLE
Changed bad param to install_dir variable

### DIFF
--- a/templates/default/kibana-apache.conf.erb
+++ b/templates/default/kibana-apache.conf.erb
@@ -3,8 +3,8 @@
 
   ServerAlias <%= @params[:server_aliases].join(" ") %>
 
-  DocumentRoot <%= node['kibana'][:install_dir] %>
-  <Directory <%= node['kibana'][:install_dir] %>>
+  DocumentRoot <%= @params[:kibana_dir] %>
+  <Directory <%= @params[:kibana_dir] %>>
     Allow from all
     Options -Multiviews
   </Directory>


### PR DESCRIPTION
The old param "kibana_dir" was never set (or maybe just not passed), leaving the DocumentRoot and Directory directive without a setting (ie, set to an empty string).  This causes httpd to be unable to start.  Now we just use the "install_dir" variable which does the right thing.
