### PR TITLE
Adds `install_method` attribute which tells how nginx should be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As with most cookbooks I write, this one is hopefully flexible enough to be wrap
 
 #### kibana::nginx
 
+- `node['kibana']['nginx']['install_method']` - nginx install method: `source` or `package` (default: package)
 - `node['kibana']['nginx']['template']` - The template file to use for the nginx site configuration
 - `node['kibana']['nginx']['template_cookbook']` - The cookbook containing said template
 - `node['kibana']['nginx']['enable_default_site']` - Should we disable the nginx default site (default: true)

--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -1,3 +1,4 @@
+default['kibana']['nginx']['install_method'] = 'package'
 default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
 default['kibana']['nginx']['template_cookbook'] = 'kibana'
 default['kibana']['nginx']['enable_default_site'] = false

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -19,10 +19,11 @@
 
 
 node.set['nginx']['default_site_enabled'] = node['kibana']['nginx']['enable_default_site']
+node.set['nginx']['install_method'] = node['kibana']['nginx']['install_method']
 
 include_recipe "nginx"
 
-template "/etc/nginx/sites-available/kibana" do
+template "#{node['nginx']['dir']}/sites-available/kibana" do
   source node['kibana']['nginx']['template']
   cookbook node['kibana']['nginx']['template_cookbook']
   notifies :reload, "service[nginx]"


### PR DESCRIPTION
I found that it always installs nginx from package even if node has `recipe[nginx::source]` in it's runlist which ends in 2 nginx being installed.
