### PR TITLE
fix field name

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -12,7 +12,7 @@ require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
 def load_current_resource
-  @name = new_resource.user
+  @user = new_resource.user
   @group = new_resource.group || @user
   @home = new_resource.home || "/home/#{@user}"
 end


### PR DESCRIPTION
could not provision a kibana when the user was set. found out the field names in the provider seem to differ. simple fix, does the trick for me, but please review since i'm relatively new to chef.
