### PR TITLE
Correct name attribute for user resource

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -12,7 +12,7 @@ require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
 def load_current_resource
-  @name = new_resource.user
+  @user = new_resource.user
   @group = new_resource.group || @user
   @home = new_resource.home || "/home/#{@user}"
 end


### PR DESCRIPTION
Converting over to the new LWRP in v1.3.0, the user resource errors out with complaints that the name is not set. The user provider looks to set @name to new_resource.user while all the subsequent code calls for @user. This change flips to @user. This tests correctly on my local instances.
