### PR TITLE
fix so that updates don't fail when using the 'file' method to install Kibana

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -57,15 +57,15 @@ action :create do
     @run_context.include_recipe 'libarchive::default'
     case kb_args[:file_type]
     when 'tgz', 'zip'
-      res = remote_file "#{Chef::Config[:file_cache_path]}/kibana_#{kb_args[:name]}.tar.gz" do
+      res = remote_file "#{Chef::Config[:file_cache_path]}/kibana_#{kb_args[:file_version]}_#{kb_args[:name]}.tar.gz" do
         checksum kb_args[:file_checksum]
         source kb_args[:file_url]
         action [:create_if_missing]
       end
       new_resource.updated_by_last_action(res.updated_by_last_action?)
 
-      res = libarchive_file "kibana_#{kb_args[:name]}.tar.gz" do
-        path "#{Chef::Config[:file_cache_path]}/kibana_#{kb_args[:name]}.tar.gz"
+      res = libarchive_file "kibana_#{kb_args[:file_version]}_#{kb_args[:name]}.tar.gz" do
+        path "#{Chef::Config[:file_cache_path]}/kibana_#{kb_args[:file_version]}_#{kb_args[:name]}.tar.gz"
         extract_to kb_args[:install_dir]
         owner kb_args[:user]
         action [:extract]


### PR DESCRIPTION
Current, if you the version of kibana updates, the 'file' update method will fail. This is as the archive temp filename does not include the version, so won't be refreshed. This then results in the 'current' symlink (which does include the version) becoming broken.