### PR TITLE
update kibana.yml with kibana4-beta3 attributes

### DIFF
--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -21,10 +21,6 @@ request_timeout: 60
 # Set to 0 to disable (not recommended).
 shard_timeout: 30000
 
-# Set to false to have a complete disregard for the validity of the SSL
-# certificate.
-verify_ssl: true
-
 # Plugins that are included in the build, and no longer found in the plugins/ folder
 bundledPluginIds:
  - plugins/dashboard/index

--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -6,15 +6,33 @@ elasticsearch: "<%= @elasticsearch %>"
 
 # Kibana uses and index in Elasticsearch to store saved searches, visualizations
 # and dashboard. It will create an new index if it doesn't already exist.
-kibanaIndex: "<%= @index %>"
+kibana_index: "<%= @index %>"
 
-# Applications loaded and included into Kibana. Use the settings below to
-# customize the applications and thier names.
-apps:
-  - { id: "discover", name: "Discover" }
-  - { id: "visualize", name: "Visualize" }
-  - { id: "dashboard", name: "Dashboard" }
-  - { id: "settings", name: "Settings" }
+# The default application to load.
+default_app_id: "discover"
 
-# The default application to laad.
-defaultAppId: "discover"
+# Time in seconds to wait for responses from the back end or elasticsearch.
+# Note this should always be higher than "shard_timeout".
+# This must be > 0
+request_timeout: 60
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Note this should always be lower than "request_timeout".
+# Set to 0 to disable (not recommended).
+shard_timeout: 30000
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundledPluginIds:
+ - plugins/dashboard/index
+ - plugins/discover/index
+ - plugins/doc/index
+ - plugins/kibana/index
+ - plugins/metric_vis/index
+ - plugins/settings/index
+ - plugins/table_vis/index
+ - plugins/vis_types/index
+ - plugins/visualize/index


### PR DESCRIPTION
This cookbook is currently throwing an error wth kibana4-beta3 as the kibana.yml still has attribute names from the old version that are no longer applicable.  This PR updates the yml file to correct this.