### PR TITLE
Add guard to libarchive extraction

### DIFF
--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -90,6 +90,7 @@ class Chef
                 extract_to kb_args[:install_dir]
                 owner kb_args[:user]
                 action [:extract]
+                not_if do ::File.exists?("#{kb_args[:install_dir]}/kibana-#{kb_args[:version]}") end
               end
 
               link "#{kb_args[:install_dir]}/current" do


### PR DESCRIPTION
When using the kibana_install resource and looking at chef-client traces, I noticed that the resource would run the extraction of the downloaded kibana tar.gz every chef run. This in turn would mean that the kibana.yml template needed to be updated (as kibana was essentially reinstalled) and the service restarted. 

This is not ideal. I have added a guard to the extraction that looks for the extracted folder name. If that version of kibana has already been installed, it will not extract the tar.gz again.