### PR TITLE
request_timeout uses milliseconds not seconds

### DIFF
--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -11,10 +11,9 @@ kibana_index: "<%= @index %>"
 # The default application to load.
 default_app_id: "discover"
 
-# Time in seconds to wait for responses from the back end or elasticsearch.
-# Note this should always be higher than "shard_timeout".
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-request_timeout: 60
+request_timeout: 60000
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
 # Note this should always be lower than "request_timeout".


### PR DESCRIPTION
I was seeing multiple timeout errors in the kibana logs and I could not get my data to display using kibana installed via this cookbook. After looking at the config from the upstream tarball, it looks like they changed the request_timeout parameter to take milliseconds rather than seconds.

I fixed the millisecond vs second issue and copied the parameter explanation from the upstream default config.