### PR TITLE
Update for compat with new poise 2.0 release

### DIFF
--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -7,6 +7,8 @@
 #
 # Copyright 2014, John E. Vincent
 
+require 'poise'
+
 class Chef
   class Resource::KibanaInstall < Resource
     include Poise

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -7,6 +7,8 @@
 #
 # Copyright 2014, John E. Vincent
 
+require 'poise'
+
 class Chef
   class Resource::KibanaUser < Resource
     include Poise

--- a/libraries/web.rb
+++ b/libraries/web.rb
@@ -7,6 +7,8 @@
 #
 # Copyright 2014, John E. Vincent
 
+require 'poise'
+
 class Chef
   class Resource::KibanaWeb < Resource
     include Poise


### PR DESCRIPTION
- Add `require 'poise'` to be compatible with [new release of poise](https://github.com/poise/poise/blob/master/CHANGELOG.md#v200) as gem, fixes #90.