### PR TITLE
Update Apache Template

### DIFF
--- a/templates/default/kibana-apache_file.conf.erb
+++ b/templates/default/kibana-apache_file.conf.erb
@@ -3,7 +3,11 @@
 
   ServerAlias <%= @params[:server_aliases].join(" ") %>
 
-  ProxyPass / http://0.0.0.0:8080/
-  ProxyPassReverse / http://0.0.0.0:8080/
+  ProxyPass / http://0.0.0.0:<%= @kibana_port %>/
+  ProxyPassReverse / http://0.0.0.0:<%= @kibana_port %>/
+  
+  <Location / >
+    Require all granted
+  </Location>
 
 </VirtualHost>


### PR DESCRIPTION
The apache template does not leverage the `@kibana_port` variable and is hardcoded to 8080. The current template also does not work with the access permissions under apache24. This change leverages the `@kibana_port` variable like the nginx template and also adds a `Location` clause to allow proxying to work.