### PR TITLE
Make default_app_id configurable via attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,7 @@ default['kibana']['user'] = 'kibana'
 default['kibana']['config']['kibana_index']  = 'kibana-int'
 default['kibana']['config']['panel_names']   =  %w(histogram map pie table filtering timepicker text fields hits dashcontrol column derivequeries trends bettermap query terms)
 default['kibana']['config']['default_route'] = '/dashboard/file/logstash.json'
+default['kibana']['config']['default_app_id'] = 'discover'
 # include quote inside this next variable if not using window.location style variables...
 # e.g.  = "'http://elasticsearch.example.com:9200'"
 default['kibana']['config']['elasticsearch'] = "window.location.protocol+\"//\"+window.location.hostname+\":\"+window.location.port"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -66,7 +66,8 @@ template kibana_config do
     port: node['kibana']['java_webserver_port'],
     elasticsearch: es_server,
     default_route: node['kibana']['config']['default_route'],
-    panel_names:  node['kibana']['config']['panel_names']
+    panel_names:  node['kibana']['config']['panel_names'],
+    default_app_id: node['kibana']['config']['default_app_id']
   )
 end
 

--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -9,7 +9,7 @@ elasticsearch_url: "<%= @elasticsearch %>"
 kibana_index: "<%= @index %>"
 
 # The default application to load.
-default_app_id: "discover"
+default_app_id: "<%= @default_app_id %>"
 
 # Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0


### PR DESCRIPTION
This PR exposes the `default_app_id` in kibana.yml via an attribute. Nice because you can set a default dashboard while still using the install recipe.