### PR TITLE
Removes duplicate slash

### DIFF
--- a/templates/default/sv-kibana-run.erb
+++ b/templates/default/sv-kibana-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd /<%= @options[:home] %>
+cd <%= @options[:home] %>
 exec 2>&1
 
 exec chpst -u <%= @options[:user] %> <%= @options[:home] %>/bin/kibana


### PR DESCRIPTION
Before this patch, the cd line looked like. 

    //opt/kibana/current

While technically it still worked, the first slash is not needed. 