### PR TITLE
Allowing to pass custom options to the `runit_service[kibana]` resource

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,3 +71,7 @@ default['kibana']['nginx']['install_method'] = 'package'
 default['kibana']['apache']['template'] = 'kibana-apache.conf.erb'
 default['kibana']['apache']['template_cookbook'] = 'kibana_lwrp'
 default['kibana']['apache']['enable_default_site'] = false
+
+# Service options, passed as is to the runit_service resource
+# (see https://github.com/chef-cookbooks/runit#parameter-attributes)
+default['kibana']['service']['options'] = {}

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -82,6 +82,11 @@ if install_type == 'file'
       home: "#{node['kibana']['install_dir']}/current"
     )
     cookbook 'kibana_lwrp'
+
+    node['kibana']['service']['options'].each do |option_name, option_value|
+      send(option_name, option_value)
+    end
+
     subscribes :restart, "template[#{kibana_config}]", :delayed
   end
 

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -19,6 +19,7 @@ describe 'kibana_lwrp::install' do
       runner.node.set['kibana']['nginx']['template_cookbook'] = 'kibana'
       runner.node.set['kibana']['nginx']['enable_default_site'] = false
       runner.node.set['kibana']['nginx']['install_method'] = 'package'
+      runner.node.set['kibana']['service']['options']['sv_timeout'] = 42
       runner.node.automatic['memory']['total'] = '1024kB'
       runner.converge(described_recipe)
     end
@@ -59,7 +60,7 @@ describe 'kibana_lwrp::install' do
     end
 
     it 'creates a runit service for kibana' do
-      expect(chef_run).to enable_runit_service('kibana')
+      expect(chef_run).to enable_runit_service('kibana').with(sv_timeout: 42)
     end
   end
 end


### PR DESCRIPTION
For example in our use case Kibana can take longer than 7 seconds to start,
so I'd like to be able to pass it a custom timeout.

Updated unit tests