### PR TITLE
Write logs to /var/log/kibana

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -83,6 +83,7 @@ if install_type == 'file'
       home: "#{node['kibana']['install_dir']}/current"
     )
     cookbook 'kibana_lwrp'
+    default_logger true
 
     node['kibana']['service']['options'].each do |option_name, option_value|
       send(option_name, option_value)

--- a/templates/default/sv-kibana-log-run.erb
+++ b/templates/default/sv-kibana-log-run.erb
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec svlogd -tt ./main


### PR DESCRIPTION
`/etc/sv/kibana/log/main` is a very odd place to write logs. Although the runit manual mentions `./main` as an example, the runit cookbook uses `/var/log/<service>` if you enable the default logger. The log template in this cookbook is otherwise identical to the default so we may as well remove it.

We were spammed with email and Jabber messages every time someone clicked something in Kibana after turning our OSSEC syscheck on. We will have to ignore `/etc/sv` anyway because of other runit files but logs really shouldn't go here.