### PR TITLE
Added support for Kibana 6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['kibana']['git']['type'] = 'sync' # checkout | sync
 default['kibana']['git']['config'] = 'kibana/config.js' # relative path of config file
 default['kibana']['git']['config_template'] = 'config.js.erb' # template to use for config
 default['kibana']['git']['config_template_cookbook'] = 'kibana_lwrp' # cookbook containing config template
+default['kibana']['git']['config_template5'] = 'config.js.erb'
 
 # Values to use for file method of installation
 default['kibana']['file']['type'] = 'tgz' # zip | tgz
@@ -20,6 +21,7 @@ default['kibana']['file']['checksum'] = nil # sha256 ( shasum -a 256 FILENAME )
 default['kibana']['file']['config'] = 'config/kibana.yml' # relative path of config file
 default['kibana']['file']['config_template'] = 'kibana.yml.erb' # template to use for config
 default['kibana']['file']['config_template_cookbook'] = 'kibana_lwrp' # cookbook containing config template
+default['kibana']['file']['config_template5'] = 'kibana5.yml.erb'
 
 # Kibana Java Web Server
 default['kibana']['java_webserver_port'] = 5601

--- a/libraries/web.rb
+++ b/libraries/web.rb
@@ -66,7 +66,7 @@ class Chef
         when 'nginx'
           node.set['nginx']['default_site_enabled'] = resources[:default_site_enabled]
           node.set['nginx']['install_method'] = node['kibana']['nginx']['install_method']
-          @run_context.include_recipe 'chef_nginx'
+          @run_context.include_recipe 'nginx'
 
           template "#{node['nginx']['dir']}/sites-available/#{resources[:name]}" do
             source resources[:template]

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
 version '3.0.2'
 
-%w(git chef_nginx apache2 ark libarchive java runit compat_resource).each do |cb|
+%w(git nginx apache2 ark libarchive java runit compat_resource).each do |cb|
   depends cb
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -56,8 +56,10 @@ docroot = "#{node['kibana']['install_dir']}/current/kibana"
 kibana_config = "#{node['kibana']['install_dir']}/current/#{node['kibana'][install_type]['config']}"
 es_server = "#{node['kibana']['es_scheme']}#{node['kibana']['es_server']}:#{node['kibana']['es_port']}"
 
+config_template = Gem::Version.new(node['kibana']['version'].split('-')[0]) < Gem::Version.new('6.0.0')?'config_template_5':'config_template'
+
 template kibana_config do
-  source node['kibana'][install_type]['config_template']
+  source node['kibana'][install_type][config_template]
   cookbook node['kibana'][install_type]['config_template_cookbook']
   mode '0644'
   user kibana_user

--- a/templates/default/kibana5.yml.erb
+++ b/templates/default/kibana5.yml.erb
@@ -1,29 +1,46 @@
 <% if @port %>
 # Kibana is served by a backend server. This controls which port to use.
-server.port: <%= @port %>
+port: <%= @port %>
 <% end %>
 
 <% if @elasticsearch %>
 # The Elasticsearch instance to user for all your queries
-elasticsearch.url: "<%= @elasticsearch %>"
+elasticsearch_url: "<%= @elasticsearch %>"
 <% end %>
 
 <% if @index %>
 # Kibana uses and index in Elasticsearch to store saved searches, visualizations
 # and dashboard. It will create an new index if it doesn't already exist.
-kibana.index: "<%= @index %>"
+kibana_index: "<%= @index %>"
 <% end %>
 
 <% if @default_app_id %>
 # The default application to load.
-kibana.defaultAppId: "<%= @default_app_id %>"
+default_app_id: "<%= @default_app_id %>"
+<% end %>
+
+<% if @default_route %>
+# The default route ["/"].
+server.basePath: "<%= @default_route %>"
 <% end %>
 
 # Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-elasticsearch.requestTimeout: 60000
+request_timeout: 60000
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
 # Note this should always be lower than "request_timeout".
 # Set to 0 to disable (not recommended).
-elasticsearch.shardTimeout: 30000
+shard_timeout: 30000
+
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundled_plugin_ids:
+ - plugins/dashboard/index
+ - plugins/discover/index
+ - plugins/doc/index
+ - plugins/kibana/index
+ - plugins/metric_vis/index
+ - plugins/settings/index
+ - plugins/table_vis/index
+ - plugins/vis_types/index
+ - plugins/visualize/index


### PR DESCRIPTION
This should work for Kibana 6.

I had to remove default_app_id for 6.x.y config version because I was getting problems on my current setup. If someone needs it and find a solution (or not an issue but just a problem or mine setup) feel free to add that parameter.