### PR TITLE
Replace node.set to node.default.

### DIFF
--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -69,7 +69,7 @@ class Chef
           link "#{kb_args[:install_dir]}/current" do
             to "#{kb_args[:install_dir]}/#{kb_args[:git_branch]}/src"
           end
-          node.set['kibana'][kb_args[:name]]['web_dir'] = "#{kb_args[:install_dir]}/current/src"
+          node.default['kibana'][kb_args[:name]]['web_dir'] = "#{kb_args[:install_dir]}/current/src"
 
         when 'file'
           @run_context.include_recipe 'libarchive::default'
@@ -96,7 +96,7 @@ class Chef
               to "#{kb_args[:install_dir]}/kibana-#{kb_args[:version]}"
             end
 
-            node.set['kibana'][kb_args[:name]]['web_dir'] = "#{kb_args[:install_dir]}/current"
+            node.default['kibana'][kb_args[:name]]['web_dir'] = "#{kb_args[:install_dir]}/current"
             node.save unless Chef::Config[:solo]
           end
         end # end case

--- a/libraries/web.rb
+++ b/libraries/web.rb
@@ -39,10 +39,10 @@ class Chef
 
         case resources[:type]
         when 'apache'
-          node.set['apache']['default_site_enabled'] = resources[:default_site_enabled]
+          node.default['apache']['default_site_enabled'] = resources[:default_site_enabled]
 
-          node.set['apache']['listen_ports'] = [] unless resources[:default_site_enabled]
-          node.set['apache']['listen_ports'] << resources[:listen_port]
+          node.default['apache']['listen_ports'] = [] unless resources[:default_site_enabled]
+          node.default['apache']['listen_ports'] << resources[:listen_port]
 
           %w(apache2 apache2::mod_dir apache2::mod_proxy apache2::mod_proxy_http).each do |recipe|
             @run_context.include_recipe recipe
@@ -64,8 +64,8 @@ class Chef
           end
 
         when 'nginx'
-          node.set['nginx']['default_site_enabled'] = resources[:default_site_enabled]
-          node.set['nginx']['install_method'] = node['kibana']['nginx']['install_method']
+          node.default['nginx']['default_site_enabled'] = resources[:default_site_enabled]
+          node.default['nginx']['install_method'] = node['kibana']['nginx']['install_method']
           @run_context.include_recipe 'chef_nginx'
 
           template "#{node['nginx']['dir']}/sites-available/#{resources[:name]}" do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,7 +22,7 @@ install_type = node['kibana']['install_type']
 unless Chef::Config[:solo]
   es_server_results = search(:node, "roles:#{node['kibana']['es_role']} AND chef_environment:#{node.chef_environment}")
   unless es_server_results.empty?
-    node.set['kibana']['es_server'] = es_server_results[0]['ipaddress']
+    node.default['kibana']['es_server'] = es_server_results[0]['ipaddress']
   end
 end
 

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -8,7 +8,7 @@ describe 'kibana_lwrp::default' do
     let(:node) { runner.node }
     let(:chef_run) do
       # runner.node.set['logstash'] ...
-      runner.node.set['kibana']['legacy_mode'] = 'false'
+      runner.node.default['kibana']['legacy_mode'] = 'false'
       runner.node.automatic['memory']['total'] = '1024kB'
       runner.converge(described_recipe)
     end

--- a/test/unit/spec/install_spec.rb
+++ b/test/unit/spec/install_spec.rb
@@ -7,19 +7,19 @@ describe 'kibana_lwrp::install' do
     let(:runner) { ChefSpec::ServerRunner.new(::UBUNTU_OPTS) }
     let(:node) { runner.node }
     let(:chef_run) do
-      # runner.node.set['logstash'] ...
-      runner.node.set['kibana']['user'] = 'kibanana'
-      runner.node.set['kibana']['install_dir'] = '/opt/kibanana'
-      runner.node.set['kibana']['install_type'] = 'file'
-      runner.node.set['kibana']['config_template'] = 'config.js.erb'
-      runner.node.set['kibana']['config_cookbook'] = 'kibana'
-      runner.node.set['kibana']['webserver'] = 'nginx'
-      runner.node.set['kibana']['es_server'] = '127.0.0.1'
-      runner.node.set['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
-      runner.node.set['kibana']['nginx']['template_cookbook'] = 'kibana'
-      runner.node.set['kibana']['nginx']['enable_default_site'] = false
-      runner.node.set['kibana']['nginx']['install_method'] = 'package'
-      runner.node.set['kibana']['service']['options']['sv_timeout'] = 42
+      # runner.node.default['logstash'] ...
+      runner.node.default['kibana']['user'] = 'kibanana'
+      runner.node.default['kibana']['install_dir'] = '/opt/kibanana'
+      runner.node.default['kibana']['install_type'] = 'file'
+      runner.node.default['kibana']['config_template'] = 'config.js.erb'
+      runner.node.default['kibana']['config_cookbook'] = 'kibana'
+      runner.node.default['kibana']['webserver'] = 'nginx'
+      runner.node.default['kibana']['es_server'] = '127.0.0.1'
+      runner.node.default['kibana']['nginx']['template'] = 'kibana-nginx.conf.erb'
+      runner.node.default['kibana']['nginx']['template_cookbook'] = 'kibana'
+      runner.node.default['kibana']['nginx']['enable_default_site'] = false
+      runner.node.default['kibana']['nginx']['install_method'] = 'package'
+      runner.node.default['kibana']['service']['options']['sv_timeout'] = 42
       runner.node.automatic['memory']['total'] = '1024kB'
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
To fix below error. on chef 14.5.33 + kibana_lwrp 3.0.2.
I replaced node.set to node.default simply.

```
================================================================================
Error executing action `create` on resource 'kibana_install[kibana]'
================================================================================

Chef::Node::AttributeDoesNotExistError
--------------------------------------
No attribute `node['set']' exists on
the current node. Specifically the `set' attribute is not
defined. Please make sure you have spelled everything correctly.

Cookbook Trace:
---------------
/etc/chef/local-mode-cache/cache/cookbooks/kibana_lwrp/libraries/install.rb:99:in `block (2 levels) in <class:KibanaInstall>'
/etc/chef/local-mode-cache/cache/cookbooks/kibana_lwrp/libraries/install.rb:51:in `block in <class:KibanaInstall>'
```

see: https://github.com/chef/chef/commit/34a09206c12e0bb8b658ebd8a64a76411a17afd6